### PR TITLE
Debug latex rendering for (\x. x) 1

### DIFF
--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -102,7 +102,7 @@ latexifyVar x = case splitVar x of
 wrapVar :: String -> Name a -> String
 wrapVar wrap x = case splitVar x of
   (x', "") -> "\\" ++ wrap ++ "{" ++ x' ++ "}"
-  (x', n) -> "\\" ++ wrap ++ "{" ++ x' ++ "}_{" ++ n ++ "}}"
+  (x', n) -> "\\" ++ wrap ++ "{" ++ x' ++ "}_{" ++ n ++ "}"
 
 showsPrecTyp :: Int -> Typ -> FreshM ShowS
 showsPrecTyp _ TInt = return $ showString "\\texttt{Int}"


### PR DESCRIPTION
Correct malformed LaTeX output for suffixed variables by removing an extraneous brace in `wrapVar`.

---
<a href="https://cursor.com/background-agent?bcId=bc-442810d4-3c54-4bb9-988e-4938134c9dd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-442810d4-3c54-4bb9-988e-4938134c9dd9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

